### PR TITLE
Calls to render inside overridden render method can be recursive

### DIFF
--- a/lib/express-layouts.js
+++ b/lib/express-layouts.js
@@ -51,7 +51,7 @@ function parseMetas(locals) {
 }
 
 module.exports = function (req, res, next) {
-  var render = res.render;
+  if(!res.__render) res.__render = res.render;
 
   res.render = function (view, options, fn) {
     var layout, self = this, app = req.app,
@@ -64,7 +64,7 @@ module.exports = function (req, res, next) {
     }
 
     if (options.layout === false || ((options.layout || defaultLayout) === false)) {
-      render.call(res, view, options, fn);
+      res.__render.call(res, view, options, fn);
       return;
     }
 
@@ -74,7 +74,7 @@ module.exports = function (req, res, next) {
     }
 
     options.contentFor = contentFor;
-    render.call(res, view, options, function (err, str) {
+    res.__render.call(res, view, options, function (err, str) {
       var l, locals;
 
       if (err) { return fn ? fn(err) : next(err); }
@@ -105,7 +105,7 @@ module.exports = function (req, res, next) {
       }
 
       parseContents(locals);
-      render.call(self, layout, locals, fn);
+      res.__render.call(self, layout, locals, fn);
     });
   };
   next();


### PR DESCRIPTION
This is a little bit confusing to explain, but basically some `res.render` end up embedding a layout inside a layout or some other weird issues. 

I believe this is an issue if you use this module with express mounted applications.

I was able to trace down the problem to how the original `res.render` gets assigned to a `render` variable. 

The solution to the issues I was experiencing was to ensure we only assign the variable once. So, instead of how is currently done:
```js
module.exports = function (req, res, next) {
  var render = res.render;
```

You would do the following:

```js
module.exports = function (req, res, next) {
  if(!res.__render) res.__render = res.render;
```