### PR TITLE
added meta ignore support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -193,6 +193,7 @@ Works exactly like script blocks extraction except:
 * Supported tags are `<meta …>` and `<meta …/>`
 * The option is named `extractMetas`
 * The template variable in layout is `meta`
+* use `ignore-parse` attribute to ignore meta parsing.
 
 ### Set custom default layout
 

--- a/lib/express-layouts.js
+++ b/lib/express-layouts.js
@@ -42,7 +42,7 @@ function parseStyles(locals) {
 }
 
 function parseMetas(locals) {
-  var str = locals.body, regex = /\<meta[\s\S]*?\>/g;
+  var str = locals.body, regex = /\<meta(?!.*?(ignore-parse))[\s\S]*?\/?>/g;
 
   if (regex.test(str)) {
     locals.body = str.replace(regex, '');

--- a/lib/express-layouts.js
+++ b/lib/express-layouts.js
@@ -104,7 +104,7 @@ module.exports = function (req, res, next) {
         parseStyles(locals);
       }
 
-      if (options.extractMetas === true || (options.extractMetas === undefined && app.get('layout extractMetas') === true)) {
+      if (options.extractMetas === true || (options.extractMetas === undefined && app.get('layout extractMetas') === false)) {
         locals.meta = '';
         parseMetas(locals);
       }


### PR DESCRIPTION
I was having a problem keeping meta at the required place as `parseMetas` function extract all the meta element. For example, it is required to keep meta between the elements when defining google SEO schema.

Added `ignore-parse` attribute to `parseMetas` function as a look ahead regex.

Also, I tried creating test but was not successful due to less knowledge and experience with testing, 

