### PR TITLE
Making the parser properly handle lines terminated by CRLF

### DIFF
--- a/lib/express-layouts.js
+++ b/lib/express-layouts.js
@@ -8,7 +8,7 @@ function contentFor(contentName) {
 
 function parseContents(locals) {
   var name, i = 1, str = locals.body,
-    regex = new RegExp('\n?' + contentPattern + '.+?' + contentPattern + '\n?', 'g'),
+    regex = new RegExp('\r?\n?' + contentPattern + '.+?' + contentPattern + '\r?\n?', 'g'),
     split = str.split(regex),
     matches = str.match(regex);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-ejs-layouts",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "layout",
     "ejs"
   ],
-  "version": "2.5.0",
+  "version": "2.5.1",
   "main": "lib/express-layouts.js",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Current regexp only handles files with LF-terminated lines.

`regex = new RegExp('\n?' + contentPattern + '.+?' + contentPattern + '\n?', 'g')`

That causes in-browser debugging to always visually stop at the wrong line when the EJS file has lines actually terminated by CRLF.

For example, if you add a `debugger` statement or another kind of breakpoint in a JavaScript (inside a EJS file), when the browser reaches the breakpoint, it visually highlights a line X lines above or below the actual line where the breakpoint is, making the debug process highly misleading.

That happens because current regexp consumes only LF's, which, in a CRLF-terminated file, leaves a bunch of orphans CR's. That messes up the browser, which, in turn, sees several CRLF-terminated lines and a handful of CR-terminated lines...

So, I replaced the regexp

`regex = new RegExp('\n?' + contentPattern + '.+?' + contentPattern + '\n?', 'g')`

with

`regex = new RegExp('\r?\n?' + contentPattern + '.+?' + contentPattern + '\r?\n?', 'g')`

If I'm not wrong, this new regexp should even handle files created on old Mac's, which are neither LF nor CRLF-terminated, but CR-terminated 😳